### PR TITLE
add implement the Hashable & Equatable to SmartIgnored

### DIFF
--- a/Sources/SmartCodable/Core/PropertyWrapper/SmartIgnored.swift
+++ b/Sources/SmartCodable/Core/PropertyWrapper/SmartIgnored.swift
@@ -62,6 +62,17 @@ public struct SmartIgnored<T>: PropertyWrapperable {
     }
 }
 
+extension SmartIgnored: Equatable where T: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.wrappedValue == rhs.wrappedValue
+    }
+}
+
+extension SmartIgnored: Hashable where T: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        wrappedValue.hash(into: &hasher)
+    }
+}
 
 extension SmartIgnored: Codable {
     public init(from decoder: Decoder) throws {


### PR DESCRIPTION
## 问题

在使用`NSDiffableDataSourceSnapshot` 时，`snapshot`要求`Item`遵守`Hashable`协议，假如 `Item`中的某个属性被`@SmartIgnored`标记，会因为`@SmartIgnored`未实现`Hashable`协议而编译失败。

当然使用者也可以自己解决，比如不用 `@SmartIgnored` , 或者项目中自己对 `SmartIgnored` 添加 `Hashable` extetion。不过我感觉这是一个比较常见的业务场景，所以提了这个`MR`。

## Code

```swift
struct RewardModel: Hashable, SmartCodable {
    // MARK: Properties

    var rewardId: Int = 0
    var rewardName: String = ""
    var rewardIcon: String = ""
    var unitText: String = ""

    @SmartIgnored
    var contributeLevel: ContributeLevel = .none
}

// MARK: - ContributeLevel

enum ContributeLevel: Int, Hashable, SmartCaseDefaultable {
    case none = 0, low, high, top1
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SmartIgnored now conforms to Equatable and Hashable when its wrapped type does, allowing direct comparisons and hashing. This enables use in sets, as dictionary keys, and simplifies testing and state diffs. Improves interoperability with Swift collections and algorithms without requiring workarounds. No behavior changes for non-Equatable/Hashable types. Backwards compatible. No API removals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->