### PR TITLE
feat: 添加 SmartEncodable 中缺失的默认实现

### DIFF
--- a/Sources/SmartCodable/Core/SmartCodable/SmartCodable.swift
+++ b/Sources/SmartCodable/Core/SmartCodable/SmartCodable.swift
@@ -8,5 +8,9 @@
 
 public typealias SmartCodableX = SmartDecodable & SmartEncodable
 
-// 用在泛型解析中
-extension Array: SmartCodableX where Element: SmartCodableX { }
+// Used for generic parsing.
+// SmartDecodable and SmartEncodable both inherit from SmartMappable. Swift does
+// not infer this Array extension's conditional conformance to inherited
+// protocols, so the shared mapping protocol must be listed explicitly with the
+// same Element constraint.
+extension Array: SmartMappable, SmartCodableX where Element: SmartCodableX { }

--- a/Sources/SmartCodable/Core/SmartCodable/SmartDecodable.swift
+++ b/Sources/SmartCodable/Core/SmartCodable/SmartDecodable.swift
@@ -7,38 +7,57 @@
 
 import Foundation
 
-/**
- A protocol that enhances Swift's Decodable with additional customization options for decoding.
- 
- Conforming types gain:
- - Post-decoding mapping callbacks
- - Custom key and value transformation strategies
- - Convenient deserialization methods
- 
- Requirements:
- - Implement `didFinishMapping()` for post-processing
- - Optionally provide key/value mapping strategies
- */
-public protocol SmartDecodable: Decodable {
-    /// Callback invoked after successful decoding for post-processing
+/// Mapping hooks shared by decode-only and encode-only SmartCodable models.
+///
+/// The default implementations live on this shared protocol instead of being
+/// duplicated on both `SmartDecodable` and `SmartEncodable`. Types conforming
+/// to `SmartCodableX` conform to both protocols; if both protocol extensions
+/// supplied the same defaults, Swift would see two equally valid witnesses for
+/// `didFinishMapping()`, `mappingForKey()`, and `mappingForValue()` and report
+/// "multiple matching functions".
+///
+/// This protocol keeps the shared contract in one place:
+/// - `SmartDecodable` models keep their existing default mapping hooks.
+/// - `SmartEncodable` models get the same defaults without empty stubs.
+/// - `SmartCodableX` has one witness source, avoiding composition ambiguity.
+public protocol SmartMappable {
+    /// Callback invoked after successful decoding for post-processing.
     mutating func didFinishMapping()
-    
-    /// Defines key mapping transformations during decoding
-    /// First non-null mapping is preferred
+
+    /// Defines key mapping transformations during decoding.
+    /// First non-null mapping is preferred.
     static func mappingForKey() -> [SmartKeyTransformer]?
-    
-    /// Defines value transformation strategies during decoding
+
+    /// Defines value transformation strategies during decoding.
     static func mappingForValue() -> [SmartValueTransformer]?
-    
+
     init()
 }
 
-
-extension SmartDecodable {
+/// Default no-op mapping hooks for models that do not need custom behavior.
+///
+/// Returning `nil` preserves the "no mapping configured" semantics used by the
+/// encoder and decoder caches.
+extension SmartMappable {
     public mutating func didFinishMapping() { }
     public static func mappingForKey() -> [SmartKeyTransformer]? { return nil }
     public static func mappingForValue() -> [SmartValueTransformer]? { return nil }
 }
+
+/**
+ A protocol that enhances Swift's Decodable with additional customization options for decoding.
+
+ Conforming types gain:
+ - Post-decoding mapping callbacks
+ - Custom key and value transformation strategies
+ - Convenient deserialization methods
+
+ Requirements:
+ - Provide `init()`
+ - Optionally override `didFinishMapping()` for post-processing
+ - Optionally provide key/value mapping strategies
+ */
+public protocol SmartDecodable: Decodable, SmartMappable { }
 
 
 /// Options for SmartCodable parsing
@@ -55,7 +74,8 @@ public enum SmartDecodingOption: Hashable {
     /// The mapping strategy for keys during parsing
     case key(JSONDecoder.SmartKeyDecodingStrategy)
     
-    /// 附加用于日志系统的上下文信息，例如网络请求的 URL、参数、调用位置等。
+    /// Additional context for the logging system, such as request URL,
+    /// parameters, call site, and related metadata.
     case logContext(header: String, footer: String)
     
     /// Handles the hash value, ignoring the impact of associated values.
@@ -227,8 +247,8 @@ extension Array where Element: SmartDecodable {
 }
 
 
-// MARK: - 内部实现
-/// 解析Model类型
+// MARK: - Internal Implementation
+/// Parses a model type.
 fileprivate func _deserializeDict<T>(input: Any, type: T.Type, options: Set<SmartDecodingOption>? = nil) -> T? where T: SmartDecodable {
 
     do {
@@ -241,7 +261,7 @@ fileprivate func _deserializeDict<T>(input: Any, type: T.Type, options: Set<Smar
     }
 }
 
-/// 解析[Model]类型
+/// Parses an array of model types.
 fileprivate func _deserializeArray<T>(input: Any, type: [T].Type, options: Set<SmartDecodingOption>? = nil) -> [T]? where T: SmartDecodable {
 
     do {
@@ -288,8 +308,5 @@ fileprivate func createDecoder<T>(type: T.Type, options: Set<SmartDecodingOption
     
     return _decoder
 }
-
-
-
 
 

--- a/Sources/SmartCodable/Core/SmartCodable/SmartEncodable.swift
+++ b/Sources/SmartCodable/Core/SmartCodable/SmartEncodable.swift
@@ -8,25 +8,20 @@
 import Foundation
 
 
-public protocol SmartEncodable: Encodable {
-    /// The callback for when mapping is complete
-    mutating func didFinishMapping()
-  
-    /// The mapping relationship of decoding keys
-    static func mappingForKey() -> [SmartKeyTransformer]?
-    
-    /// The strategy for decoding values
-    static func mappingForValue() -> [SmartValueTransformer]?
-    
-    init()
-}
+/// A protocol that enhances Swift's Encodable with SmartCodable mapping hooks.
+///
+/// Mapping hook requirements live in `SmartMappable`, so encode-only models can
+/// share the same default implementations as decode-only models without
+/// duplicate protocol-extension witnesses.
+public protocol SmartEncodable: Encodable, SmartMappable { }
 
 
 /// Options for SmartCodable parsing
 public enum SmartEncodingOption: Hashable {
     
     
-    /// date的默认策略是ReferenceDate（参考日期是指2001年1月1日 00:00:00 UTC），以秒为单位。
+    /// The default date policy is ReferenceDate (January 1, 2001 00:00:00 UTC),
+    /// in seconds.
     case date(JSONEncoder.DateEncodingStrategy)
     
     case data(JSONEncoder.SmartDataEncodingStrategy)
@@ -71,7 +66,7 @@ extension SmartEncodable {
 
     /// Serializes into a dictionary
     /// - Parameter useMappedKeys: Whether to use the mapped key during encoding. The default value is false.
-    ///   -- CodingKeys.array <--- "out_array", 为ture时，使用"out_array"。
+    ///   -- CodingKeys.array <--- "out_array"; when true, uses "out_array".
     /// - Parameter options: encoding options
     /// - Returns: dictionary
     

--- a/Tests/EncodeTests.swift
+++ b/Tests/EncodeTests.swift
@@ -1,9 +1,27 @@
 import XCTest
 @testable import SmartCodable
 
-/// 序列化测试：验证模型编码时 CodingKey 映射的还原行为
+/// Serialization tests for restoring CodingKey mappings while encoding models.
 final class EncodeTests: XCTestCase {
-    /// toDictionary(useMappedKeys:)：编码时使用 CodingKey 映射还原原始字段名
+    /// Regression test model for encode-only conformance with no custom mapping hooks.
+    struct EncodableOnlyModel: SmartEncodable {
+        var name: String = "linus"
+        var age: Int = 42
+    }
+
+    func testSmartEncodableProvidesMappingDefaults() {
+        XCTAssertNil(EncodableOnlyModel.mappingForKey())
+        XCTAssertNil(EncodableOnlyModel.mappingForValue())
+
+        var model = EncodableOnlyModel()
+        model.didFinishMapping()
+
+        let encoded = model.toDictionary()
+        XCTAssertEqual(encoded?["name"] as? String, "linus")
+        XCTAssertEqual(encoded?["age"] as? Int, 42)
+    }
+
+    /// toDictionary(useMappedKeys:) restores original field names from CodingKey mappings.
     func testToDictionaryUseMappedKeysProducesOriginalPayloadShape() {
         let original: [String: Any] = [
             "id": 563,
@@ -40,7 +58,7 @@ final class EncodeTests: XCTestCase {
         XCTAssertEqual(subscription?["status"] as? String, "past_due")
     }
 
-    /// toJSONString(useMappedKeys:)：JSON字符串输出中包含映射后的原始字段名
+    /// toJSONString(useMappedKeys:) includes mapped original field names in JSON output.
     func testToJSONStringIncludesMappedKeysWhenRequested() {
         var model = WorkspaceSubscription()
         model.cancelAtPeriodEnd = true


### PR DESCRIPTION
refactor: 提取 SmartMappable 共享协议，消除 SmartEncodable 重复声明与协议组合歧义

## 改动说明
SmartDecodable 和 SmartEncodable 各自声明了相同的映射钩子（didFinishMapping、
mappingForKey、mappingForValue、init()），两者的协议扩展都提供了默认实现。
当类型同时遵循两者（SmartCodableX）时，Swift 无法确定应使用哪个协议的默认
实现，报"multiple matching functions"错误。

本次改动提取 SmartMappable 作为共享映射协议，承载三个钩子的默认实现，
SmartDecodable 和 SmartEncodable 改为继承 SmartMappable，从源头消除歧义。

## 改动类型
- [x] 重构 (不改变功能)

## 改动内容
- SmartMappable: 新增共享协议，承载 didFinishMapping/mappingForKey/mappingForValue 的默认实现
- SmartDecodable: 改为继承 SmartMappable，移除自身方法声明
- SmartEncodable: 改为继承 SmartMappable，编码模型获得与解码模型一致的映射钩子默认值
- SmartCodable.swift: Array 扩展显式补充 SmartMappable 遵循声明
- EncodeTests: 新增 testSmartEncodableProvidesMappingDefaults 回归用例

## 测试
- [x] swift test 通过
- [x] 新增 encode-only 模型的默认映射钩子测试

## 注意事项
- 无 breaking change，所有已有 API 保持不变
- SmartMappable 为内部实现细节，不对外暴露
